### PR TITLE
Allow the ability to specify remote paths for the SSL certificate, key, and chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,18 @@ This role must be run with sudo or as root, otherwise the role will fail.
 * **postmaster_install_mysql** - determines whether or not to install MySQL using the [geerlingguy.mysql](https://github.com/geerlingguy/ansible-role-mysql) role.
 Read the documentation of that role to find out the configuration options needed for MySQL. This defaults to `False`.
 * **postmaster_apache_port** - the port that the PostMaster virtual host listens on.
-* **postmaster_apache_ssl_cert** - the local path to the SSL certificate to use on the PostMaster virtual host. If this is not set, the virtual host will not use SSL.
-* **postmaster_apache_ssl_key** - the local path to the SSL key to use on the PostMaster virtual host. If this is not set, the virtual host will not use SSL.
-* **postmaster_apache_ssl_chain** - the local path to the SSL certificate chain to use on the PostMaster virtual host. This is not required when configuring SSL.
+* **postmaster_apache_ssl_cert** - the path on the target node to the SSL certificate to use on the PostMaster virtual host.
+If this is not set, the virtual host will not use SSL.
+* **postmaster_apache_ssl_key** - the path on the target node to the SSL key to use on the PostMaster virtual host.
+If this is not set, the virtual host will not use SSL.
+* **postmaster_apache_ssl_chain** - the path on the target node to the SSL certificate chain to use on the PostMaster virtual host.
+This is not required when configuring SSL, but it is required if `postmaster_apache_ssl_local_chain` is defined.
+* **postmaster_apache_ssl_local_cert** - the local path to the SSL certificate to copy over to the path defined in `postmaster_apache_ssl_cert`.
+This is not required.
+* **postmaster_apache_ssl_local_key** - the local path to the SSL key to copy over to the path defined in `postmaster_apache_ssl_key`.
+This is not required.
+* **postmaster_apache_ssl_local_chain** - the local path to the SSL certificate chain to copy over to the path defined in `postmaster_apache_ssl_chain`.
+This is not required.
 * **postmaster_apache_ssl_cipher_suite** - the SSL cipher suite that the PostMaster virtual host will allow. This defaults to `AES256+EECDH:AES256+EDH`.
 * **postmaster_apache_ssl_protocol** - the SSL protocols that the PostMaster virtual host will allow. This defaults to `All -SSLv2 -SSLv3`.
 * **postmaster_clean_virtualenv** - delete and recreate the PostMaster virtualenv. This is useful between upgrades to delete old and no longer used Python dependencies.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,14 @@
 ---
 postmaster_apache_port: 8082
 # This upgrades the database schema to the current version being installed
-# The migration will not run regardless of this value when postmaster_deb_packge
-# is True
+# The migration will not run regardless of this value when
+# postmaster_deb_package is True
+postmaster_migrate_db: True
 postmaster_apache_ssl_cipher_suite: AES256+EECDH:AES256+EDH
 postmaster_apache_ssl_protocol: All -SSLv2 -SSLv3
 postmaster_db_host: localhost
 postmaster_db_name: servermail
 postmaster_db_port: 3306
-postmaster_migrate_db: True
 # This runs the mysql role
 postmaster_install_mysql: False
 # This recreates the virtulenv from scratch

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ postmaster_install_mysql: False
 postmaster_clean_virtualenv: False
 # This should be True when the deb package uses the role
 postmaster_deb_package: False
+postmaster_apache_ssl_remote_src: False
 # This is hard coded because installation for every PostMaster version may be
 # different, so there will be one playbook per version of PostMaster
 # TODO: In future releases add v to the version

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -15,25 +15,27 @@
 
 - name: Copy over SSL cert
   copy:
-    src: "{{ postmaster_apache_ssl_cert }}"
-    dest: /etc/apache2/ssl/postmaster.crt
+    src: "{{ postmaster_apache_ssl_local_cert }}"
+    dest: "{{ postmaster_apache_ssl_cert }}"
     owner: root
     group: root
     mode: 0660
+  when: postmaster_apache_ssl_local_cert is defined
 
 - name: Copy over SSL key
   copy:
-    src: "{{ postmaster_apache_ssl_key }}"
-    dest: /etc/apache2/ssl/postmaster.key
+    src: "{{ postmaster_apache_ssl_local_key }}"
+    dest: "{{ postmaster_apache_ssl_key }}"
     owner: root
     group: root
     mode: 0660
+  when: postmaster_apache_ssl_local_key is defined
 
 - name: Copy over SSL chain
   copy:
-    src: "{{ postmaster_apache_ssl_chain }}"
-    dest: /etc/apache2/ssl/postmaster_chain.crt
+    src: "{{ postmaster_apache_ssl_local_chain }}"
+    dest: "{{ postmaster_apache_ssl_chain }}"
     owner: root
     group: root
     mode: 0664
-  when: postmaster_apache_ssl_chain is defined
+  when: postmaster_apache_ssl_local_chain is defined


### PR DESCRIPTION
This is useful in case you have another role or other automation that generates the SSL certificates (e.g. Let's Encrypt) on the remote server and you just need Apache to point to those.