### PR TITLE
Add postmaster_vagrant_install variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,6 @@ postmaster_apache_ssl_remote_src: False
 # This is hard coded because installation for every PostMaster version may be
 # different, so there will be one role version per version of PostMaster
 postmaster_version: v1.2.0.0
+# This should be True when run in Vagrant. It skips the source code installation
+# since Vagrant manages that
+postmaster_vagrant_install: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
     recurse: yes
 
 - include: source.yml
-  when: not postmaster_deb_package
+  when: not postmaster_deb_package and not postmaster_vagrant_install
 
 - name: Install the python dependencies
   pip:


### PR DESCRIPTION
This needs to be set in order for our Vagrant installs to not delete /opt/postmaster/git and try to download the source from GitHub... I learned this the hard way. ☹️ 