### PR TITLE
Install the dependencies in test-requirements.txt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,12 @@
     requirements: /opt/postmaster/git/requirements.txt
     virtualenv: /opt/postmaster/env
 
+- name: Install the python testing dependencies
+  pip:
+    requirements: /opt/postmaster/git/test-requirements.txt
+    virtualenv: /opt/postmaster/env
+  when: postmaster_vagrant_install
+
 - name: Configure PostMaster
   template:
     src: opt/postmaster/git/config.py.j2


### PR DESCRIPTION
Install the dependencies in test-requirements.txt when using the role in Vagrant for development.